### PR TITLE
feat: avoid loading everything in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ curl -X GET "http://localhost:8080/ports/PORT_ID"
 ### **2️⃣ Bulk Upsert Ports**
 Upload a new `ports.json` file to update all ports:
 ```sh
-curl -X POST "http://localhost:8080/ports/bulk" \
-     -H "Content-Type: application/json" \
-     --data-binary @data/ports.json
+curl -X POST "http://localhost:8080/ports/bulk" -F "file=@data/ports.json"
 ```
 ✔ **Example `ports.json`**
 ```json

--- a/src/internal/adapters/config/config_loader_test.go
+++ b/src/internal/adapters/config/config_loader_test.go
@@ -12,8 +12,7 @@ func TestLoadConfig(t *testing.T) {
 	// Create a temporary config file
 	configData := `ports_file = "data/ports.json"
 load_on_startup = true
-[server]
-port = 8080`
+`
 
 	tmpFile, err := os.CreateTemp("", "config.toml")
 	assert.NoError(t, err)

--- a/src/internal/adapters/file/json_loader.go
+++ b/src/internal/adapters/file/json_loader.go
@@ -1,48 +1,18 @@
 package file
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/vmlellis/port-sync/src/internal/domain/contract"
-	"github.com/vmlellis/port-sync/src/internal/domain/entity"
 )
 
 // ProcessJSONFile reads and processes a JSON file containing port data.
-func ProcessJSONFile(filePath string, service contract.PortService) error {
+func ProcessJSONFile(filePath string, service contract.PortService, processor contract.ProcessorService) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	decoder := json.NewDecoder(file)
-
-	// Read opening bracket
-	if _, err := decoder.Token(); err != nil {
-		return err
-	}
-
-	for decoder.More() {
-		var port entity.Port
-		key, err := decoder.Token()
-		if err != nil {
-			return err
-		}
-
-		if id, ok := key.(string); ok {
-			port.ID = id
-		} else {
-			return fmt.Errorf("unexpected key type: %T", key)
-		}
-
-		if err := decoder.Decode(&port); err != nil {
-			return err
-		}
-
-		service.SavePort(&port)
-	}
-
-	return nil
+	return processor.Process(file)
 }

--- a/src/internal/adapters/http/error.go
+++ b/src/internal/adapters/http/error.go
@@ -1,0 +1,17 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ErrResponse struct {
+	Error string `json:"error"`
+}
+
+func JSONError(w http.ResponseWriter, err string, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(ErrResponse{Error: err})
+}

--- a/src/internal/adapters/processor/parallel_processor.go
+++ b/src/internal/adapters/processor/parallel_processor.go
@@ -1,0 +1,106 @@
+package processor
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/vmlellis/port-sync/src/internal/domain/contract"
+	"github.com/vmlellis/port-sync/src/internal/domain/entity"
+)
+
+const (
+	defaultBufferedChannelSize = 100
+	defaultWorkersPoolSize     = 5
+)
+
+// ParallelProcessor implements the Processor interface.
+type ParallelProcessor struct {
+	service             contract.PortService
+	bufferedChannelSize int
+	workersPoolSize     int
+	mu                  sync.Mutex
+}
+
+// parallelProcessorOpts defines the settings
+type ParallelProcessorOpts struct {
+	BufferedChannelSize int
+	WorkersPoolSize     int
+}
+
+// NewParallelProcessor creates a new instance of ParallelProcessor.
+func NewParallelProcessor(service contract.PortService, opts ParallelProcessorOpts) contract.ProcessorService {
+	bufferedChannelSize := defaultBufferedChannelSize
+	if opts.BufferedChannelSize > 0 {
+		bufferedChannelSize = opts.BufferedChannelSize
+	}
+
+	workersPoolSize := defaultWorkersPoolSize
+	if opts.WorkersPoolSize > 0 {
+		workersPoolSize = opts.WorkersPoolSize
+	}
+
+	return &ParallelProcessor{
+		service:             service,
+		bufferedChannelSize: bufferedChannelSize,
+		workersPoolSize:     workersPoolSize,
+	}
+}
+
+func (p *ParallelProcessor) Process(rd io.Reader) error {
+
+	// Use buffered reader for efficient file reads
+	reader := bufio.NewReader(rd)
+	decoder := json.NewDecoder(reader)
+
+	// Read opening bracket
+	if _, err := decoder.Token(); err != nil {
+		return err
+	}
+
+	// Channel to pass parsed ports to worker goroutines
+	portChannel := make(chan *entity.Port, p.bufferedChannelSize)
+	var wg sync.WaitGroup
+
+	// Start worker pool with concurrent workers
+	for i := 0; i < p.workersPoolSize; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for port := range portChannel {
+				p.service.SavePort(port) // Process and store each port
+			}
+		}()
+	}
+
+	for decoder.More() {
+		var port entity.Port
+		key, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+
+		if id, ok := key.(string); ok {
+			port.ID = id
+		} else {
+			return fmt.Errorf("unexpected key type: %T", key)
+		}
+
+		if err := decoder.Decode(&port); err != nil {
+			return err
+		}
+
+		// Send the parsed port to worker pool
+		portChannel <- &port
+	}
+
+	// Close channel after sending all ports
+	close(portChannel)
+
+	// Wait for all workers to finish
+	wg.Wait()
+
+	return nil
+}

--- a/src/internal/adapters/processor/parallel_processor_test.go
+++ b/src/internal/adapters/processor/parallel_processor_test.go
@@ -1,0 +1,91 @@
+package processor_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmlellis/port-sync/src/internal/adapters/processor"
+	"github.com/vmlellis/port-sync/src/internal/adapters/storage"
+	"github.com/vmlellis/port-sync/src/internal/domain/service"
+)
+
+func TestParallelProcessor_Process(t *testing.T) {
+	// Simulate a JSON payload
+	jsonData := `{
+			"PORT1": {
+					"name": "Test Port 1",
+					"city": "Test City 1",
+					"country": "Test Country 1",
+					"coordinates": [12.34, 56.78],
+					"province": "Test Province 1",
+					"timezone": "UTC+1",
+					"unlocs": ["UNLOC1"],
+					"code": "1234"
+			},
+			"PORT2": {
+					"name": "Test Port 2",
+					"city": "Test City 2",
+					"country": "Test Country 2",
+					"coordinates": [98.76, 54.32],
+					"province": "Test Province 2",
+					"timezone": "UTC+2",
+					"unlocs": ["UNLOC2"],
+					"code": "5678"
+			}
+	}`
+
+	// Create an in-memory reader for JSON data
+	reader := bytes.NewReader([]byte(jsonData))
+
+	// Initialize storage and service
+	store := storage.NewMemoryStore()
+	portService := service.NewPortService(store)
+	processor := processor.NewParallelProcessor(portService, processor.ParallelProcessorOpts{BufferedChannelSize: 100, WorkersPoolSize: 5})
+
+	// Process the JSON data
+	err := processor.Process(reader)
+	assert.NoError(t, err)
+
+	// Verify that the ports were stored
+	retrievedPort1, found1 := portService.GetPort("PORT1")
+	retrievedPort2, found2 := portService.GetPort("PORT2")
+
+	assert.True(t, found1, "PORT1 should be found in storage")
+	assert.Equal(t, "Test Port 1", retrievedPort1.Name)
+
+	assert.True(t, found2, "PORT2 should be found in storage")
+	assert.Equal(t, "Test Port 2", retrievedPort2.Name)
+}
+
+func TestParallelProcessor_LargeDataset(t *testing.T) {
+	store := storage.NewMemoryStore()
+	portService := service.NewPortService(store)
+	processor := processor.NewParallelProcessor(portService, processor.ParallelProcessorOpts{BufferedChannelSize: 100, WorkersPoolSize: 10})
+
+	// Generate JSON for 1 million ports
+	var jsonData bytes.Buffer
+	jsonData.WriteString("{")
+	for i := 0; i < 1_000_000; i++ {
+		if i > 0 {
+			jsonData.WriteString(",")
+		}
+		jsonData.WriteString(fmt.Sprintf(`"PORT%d": {"name": "Test Port %d", "city": "Test City %d", "country": "Test Country %d"}`, i, i, i, i))
+
+	}
+	jsonData.WriteString("}")
+
+	reader := bytes.NewReader(jsonData.Bytes())
+	err := processor.Process(reader)
+	assert.NoError(t, err)
+
+	// Verify a random port is stored
+	for _, portID := range []string{"PORT1000", "PORT500000", "PORT999999"} {
+		retrievedPort, found := portService.GetPort(portID)
+		assert.True(t, found, fmt.Sprintf("%s should be found in storage", portID))
+		fmt.Printf("%v", portID)
+		fmt.Printf("%v", retrievedPort)
+		assert.Equal(t, fmt.Sprintf("Test Port %s", portID[4:]), retrievedPort.Name)
+	}
+}

--- a/src/internal/domain/contract/processor_service.go
+++ b/src/internal/domain/contract/processor_service.go
@@ -1,0 +1,9 @@
+package contract
+
+import "io"
+
+// ProcessorService interface
+type ProcessorService interface {
+	// Process a reader
+	Process(rd io.Reader) error
+}

--- a/src/internal/domain/service/port_service_test.go
+++ b/src/internal/domain/service/port_service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/vmlellis/port-sync/src/internal/adapters/storage"
 	"github.com/vmlellis/port-sync/src/internal/domain/entity"
 	"github.com/vmlellis/port-sync/src/internal/domain/service"


### PR DESCRIPTION
To handle very large bulk uploads efficiently within the 200MB memory limit, I update the project with the following improvements: 

- Chunked Processing: The file will be processed in smaller chunks instead of loading everything into RAM (`bufio.Reader`).
- Buffered Channel: Data will be passed through a limited-size channel to control memory usage.
- Parallel Processing: A worker pool will be used to speed up port processing while keeping memory usage low (`goroutines`).
- Multipart Upload Support: Large files can be uploaded in parts, reducing memory consumption. 

I created the processor adapter to process the reader (http or file).